### PR TITLE
Prevent using sudo for local actions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
   local_action:
     module: stat
     path: "{{ role_path }}/vars/{{ project_name }}_{{ env_name }}.yml"
+  become: False
   register: project_vars_file
 
 - name: Set environment variables for this project and environment


### PR DESCRIPTION
When the local account's sudo password is different from the remote
account's sudo password local_action: will fail when trying to use
become.