### PR TITLE
Add new GPG key

### DIFF
--- a/tasks/setup_mysql_yumrepo.yml
+++ b/tasks/setup_mysql_yumrepo.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Install Updated MySQL GPG Key
+  rpm_key:
+    key: https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+    state: present
+
 - name: Install MySQL yum repository
   yum:
     name: "{{ mysql_yumrepo_rpm }}"


### PR DESCRIPTION
The community release ships with an expired GPG key

```
pub   dsa1024 2003-02-03 [SCA] [expired: 2022-02-16]
      A4A9406876FCBD3C456770C88C718D3B5072E1F5
uid           MySQL Release Engineering <mysql-build@oss.oracle.com>
uid           MySQL Package signing key (www.mysql.com) <build@mysql.com>
sub   elg2048 2003-02-03 [E] [expired: 2013-09-18]
```

A new key is available
https://support.cpanel.net/hc/en-us/articles/4419382481815

```
pub   rsa4096 2021-12-14 [SC] [expires: 2023-12-14]
      859BE8D7C586F538430B19C2467B942D3A79BD29
uid           MySQL Release Engineering <mysql-build@oss.oracle.com>
sub   rsa4096 2021-12-14 [E] [expires: 2023-12-14]
```